### PR TITLE
Fix typos

### DIFF
--- a/src/modules/app.states.details/details.js
+++ b/src/modules/app.states.details/details.js
@@ -6,8 +6,8 @@
 
   var STATE_DETAILS = 'states.details';
 
-  function moieDtaResolve($stateParams,statesSvervice){//:id-----url
-    return statesSvervice.getMovie($stateParams);//id =1
+  function movieDataResolver($stateParams,statesService){//:id-----url
+    return statesService.getMovie($stateParams);//id =1
   }
 
   function config($stateProvider) {
@@ -20,7 +20,7 @@
         }
       },
       resolve: {//protect ecran,when none result
-        movieData: ['$stateParams','statesSvervice',moieDtaResolve]
+        movieData: ['$stateParams','statesService',movieDataResolver]
       }
     });
   }


### PR DESCRIPTION
Typos in dependency names prevents Angular to be able to inject them, line 23 was the most problematic here.